### PR TITLE
Renames `value-type` to `range` for `missing` nodes

### DIFF
--- a/data-model.md
+++ b/data-model.md
@@ -75,12 +75,12 @@ A mathematical formula. `value` is a string  which represents a mathematical for
 
 An unknown `resource`; also a leaf of the tree.
 Often used to tag the requested informations. It has one possible attribute:
-* `value-type` (optional) that adds information about the type of the entity.
+* `range` (optional) that adds information in which range the values that may replace this missing node should be. It may be a literal type like `time` or state that the resource should be instance of a specific class like `book`.
 
 Example:
 
 ```
-{"type": "missing", "value-type":"book"}
+{"type": "missing", "range":"book"}
 ```
 
 ### `triple`


### PR DESCRIPTION
This is in order to distinguish the range of missing nodes from the value-type of resource nodes. The value-type gives the type of the value and the range is a constraint on both type (time, string...) and kind of value (book, place...)

Moves closer to RDF (see http://www.w3.org/TR/rdf-schema/#ch_range )
