### PR TITLE
Fix sort, first and last serialization

### DIFF
--- a/data-model.md
+++ b/data-model.md
@@ -209,7 +209,7 @@ Example: the serialization of the triple `(George Washington, birth date, ?)` is
 }
 ```
 
-### *union*, *intersection*, *and*, *or*, *first* and *last*
+### *union*, *intersection*, *and* and *or*
 There is only one parameter, *list* that is an array containing the operator parameters.
 
 Example: the serialization of the query `[George Washington] ∪ [Theodore Roosevelt]` is:
@@ -231,6 +231,17 @@ Example: the serialization of the query `sort([Theodore Roosevelt, George Washin
 	"type": "sort",
 	"list": {"type":"list", "list":[{"type": "resource", "value": "Theodore Roosevelt"}, {"type": "resource", "value": "George Washington"}]},
 	"predicate": {"type": "resource", "value": "birth date"}
+}
+```
+
+### *first* and *last*
+There is only one parameter `list` that is the input list.
+
+Example: the serialization of the query `first([George Washington, Theodore Roosevelt])` is:
+```
+{
+	"type": "first",
+	"list": {"type":"list", "list":[{"type": "resource", "value": "George Washington"}, {"type": "resource", "value": "Theodore Roosevelt"}]}
 }
 ```
 


### PR DESCRIPTION
The `list` parameter gets only one node, not a list of node.

It's needed in order to do things like `sort((?, office held, president of the US), default)` because with the current serialization we would sort the list with only one element that would be the list of the US presidents.
