### PR TITLE
Add more fields to resources.

### DIFF
--- a/data-model.md
+++ b/data-model.md
@@ -117,7 +117,7 @@ The `resource` serialization has three primary attributes:
 * `range` (optional) used in order to contains type informations as specified by the typing extension of the data model.
 * `description` (optional) used to show a large portion of text. (eg. the first paragraph of a Wikipedia article)
 * `image` (optional) an URL to an image to show next to the item.
-* `buttons` (option) a list of dicts (with keys `image`, `link`, and `title`) of clickable images that lead to a more detailed page about the item. (eg. for giving credits)
+* `buttons` (optional) a list of dicts (with keys `image`, `link`, and `title`) of clickable images that lead to a more detailed page about the item. (eg. for giving credits)
 
 There may be additional attributes depending on the `value-type`.
 

--- a/data-model.md
+++ b/data-model.md
@@ -117,7 +117,7 @@ The `resource` serialization has three primary attributes:
 * `range` (optional) used in order to contains type informations as specified by the typing extension of the data model.
 * `description` (optional) used to show a large portion of text. (eg. the first paragraph of a Wikipedia article)
 * `image` (optional) an URL to an image to show next to the item.
-* `buttons` (optional) a list of dicts (with keys `image`, `link`, and `title`) of clickable images that lead to a more detailed page about the item. (eg. for giving credits)
+* `buttons` (optional) a list of objects (with keys `image`, `link`, and `title`) of clickable images that lead to a more detailed page about the item. (eg. for giving credits)
 
 There may be additional attributes depending on the `value-type`.
 

--- a/data-model.md
+++ b/data-model.md
@@ -115,6 +115,9 @@ The `resource` serialization has three primary attributes:
 * `value` that is a string representation of the resource (for interoperability).
 * `value-type` (optional) that adds information about the type of the entity. Each module can use its own types or use basic types specified just after. Default: `string`.
 * `range` (optional) used in order to contains type informations as specified by the typing extension of the data model.
+* `description` (optional) used to show a large portion of text. (eg. the first paragraph of a Wikipedia article)
+* `image` (optional) an URL to an image to show next to the item.
+* `buttons` (option) a list of dicts (with keys `image`, `link`, and `title`) of clickable images that lead to a more detailed page about the item. (eg. for giving credits)
 
 There may be additional attributes depending on the `value-type`.
 


### PR DESCRIPTION
This is only a proposal and is totally open to debate.
We should be at least three to agree on something before merging.

Possible improvements:
* Extend this to any node type and not just resources. (Would it make sense?)
* Make the `image` attributes of buttons optional. (Not sure this would give a good rendering on most UIs)

Motivations:
* This basically extends what the WebUI does for Wikipedia entries to any source of data (eg. would be useful to the OEIS module)
* This would move the Wikipedia request from the WebUI to the Wikidata module (instant loading instead of ~0.5s)