### PR TITLE
+ resource-jsonld

### DIFF
--- a/data-model.md
+++ b/data-model.md
@@ -175,12 +175,12 @@ A geographic data structure encoded using [GeoJSON](http://geojson.org/). `value
 ##### `resource-jsonld`
 A resource described in [JSON-LD](http://json-ld.org/). `value` is a human readable string representation and `graph` is the JSON-LD graph describing the resource.
 
-The JSON-LD graph should use as much as possible [schema.org vocabulary](http://schema.org/) vocabulary in order to increase module interoperability.
+The JSON-LD graph should use as much as possible [schema.org vocabulary](http://schema.org/) vocabulary in order to increase interoperability between modules.
 The graph must be [compacted](http://www.w3.org/TR/json-ld/#compacted-document-form), have as root a [node object](http://www.w3.org/TR/json-ld/#dfn-node-object) describing the resource and use `http://schema.org/` as context.
 
-You mustn't use the [schema:url](http://schema.org/url) property but instead the [`@id` keyword](http://www.w3.org/TR/json-ld/#node-identifiers).
+You must not use the [schema:url](http://schema.org/url) property but instead the [`@id` keyword](http://www.w3.org/TR/json-ld/#node-identifiers).
 
-Note: use as *[schema:sameAs](http://schema.org/sameAs)* only URIs that identifies the same resource. For example, for Douglas Adams, you can state that he is *schema:sameAs* *http://wikidata.org/entity/Q42* but not *schema:sameAs* *http://en.wikipedia.org/wiki/Douglas_Adams*, because the later is the URI of an article about Douglas Adams but not an URI for Douglas Adams himself.
+Note: use as *[schema:sameAs](http://schema.org/sameAs)* only URIs that identify the same resource. For example, for Douglas Adams, you can state that he is *schema:sameAs* *http://wikidata.org/entity/Q42* but not *schema:sameAs* *http://en.wikipedia.org/wiki/Douglas_Adams*, because the later is the URI of an article about Douglas Adams but not an URI for Douglas Adams himself.
 
 ```
 {

--- a/data-model.md
+++ b/data-model.md
@@ -184,19 +184,25 @@ Note: use only URIs that identify the same resource as *[schema:sameAs](http://s
 
 ```
 {
-	"@context": "http://schema.org/",
-	"@type": "Person",
-	"name": {"@value": "Douglas Adams", "@language": "en"},
-	"description": [
-		{"@value": "English writer and humorist", "@language": "en"},
-		{"@value": "écrivain anglais de science-fiction", "@language": "fr"}
-	],
-	"sameAs": "http://www.wikidata.org/entity/Q42",
-	"image": {
-		"@type": "ImageObject",
-		"contentUrl": "http://upload.wikimedia.org/wikipedia/commons/c/c0/Douglas_adams_portrait_cropped.jpg",
-		"name": "Douglas adams portrait cropped.jpg"
-	}
+    "@context": "http://schema.org/",
+    "@type": "Person",
+    "name": {"@value": "Douglas Adams", "@language": "en"},
+    "description": [
+        {"@value": "English writer and humorist", "@language": "en"},
+        {"@value": "écrivain anglais de science-fiction", "@language": "fr"}
+    ],
+    "sameAs": "http://www.wikidata.org/entity/Q42",
+    "image": {
+        "@type": "ImageObject",
+        "contentUrl": "//upload.wikimedia.org/wikipedia/commons/c/c0/Douglas_adams_portrait_cropped.jpg",
+        "name": "Douglas adams portrait cropped.jpg"
+    },
+    "potentialAction": {
+        "@type": "ViewAction",
+        "name": [{"@value": "View on Wikidata", "@language": "en"}, {"@value": "Voir sur Wikidata", "@language": "fr"}],
+        "image": "//upload.wikimedia.org/wikipedia/commons/f/ff/Wikidata-logo.svg",
+        "target": "//www.wikidata.org/wiki/Q42"
+    }
 }
 ```
 

--- a/data-model.md
+++ b/data-model.md
@@ -180,7 +180,7 @@ The graph must be [compacted](http://www.w3.org/TR/json-ld/#compacted-document-f
 
 You must not use the [schema:url](http://schema.org/url) property but instead the [`@id` keyword](http://www.w3.org/TR/json-ld/#node-identifiers).
 
-Note: use only URIs that identify the same resource as *[schema:sameAs](http://schema.org/sameAs)* value. For example, for Douglas Adams, you can state that he is *schema:sameAs* *http://wikidata.org/entity/Q42* but not *schema:sameAs* *http://en.wikipedia.org/wiki/Douglas_Adams*, because the later is the URI of an article about Douglas Adams but not an URI for Douglas Adams himself.
+Note: use only URIs that identify the same resource as *[schema:sameAs](http://schema.org/sameAs)* value. For example, you can state that Douglas Adams is *schema:sameAs* *http://wikidata.org/entity/Q42* but not *schema:sameAs* *http://en.wikipedia.org/wiki/Douglas_Adams*, because the later is the URI of an article about Douglas Adams but not an URI for Douglas Adams himself.
 
 ```
 {

--- a/data-model.md
+++ b/data-model.md
@@ -172,6 +172,50 @@ A geographic data structure encoded using [GeoJSON](http://geojson.org/). `value
 }
 ```
 
+##### `resource-jsonld`
+A resource described in [JSON-LD](http://json-ld.org/). `value` is a human readable string representation and `graph` is the JSON-LD graph describing the resource.
+
+The JSON-LD graph should use as much as possible [schema.org vocabulary](http://schema.org/) vocabulary in order to increase module interoperability.
+The graph must be [compacted](http://www.w3.org/TR/json-ld/#compacted-document-form), have as root a [node object](http://www.w3.org/TR/json-ld/#dfn-node-object) describing the resource and use `http://schema.org/` as context.
+
+You mustn't use the [schema:url](http://schema.org/url) property but instead the [`@id` keyword](http://www.w3.org/TR/json-ld/#node-identifiers).
+
+Note: use as *[schema:sameAs](http://schema.org/sameAs)* only URIs that identifies the same resource. For example, for Douglas Adams, you can state that he is *schema:sameAs* *http://wikidata.org/entity/Q42* but not *schema:sameAs* *http://en.wikipedia.org/wiki/Douglas_Adams*, because the later is the URI of an article about Douglas Adams but not an URI for Douglas Adams himself.
+
+```
+{
+	"@context": "http://schema.org/",
+	"@type": "Person",
+	"name": {"@value": "Douglas Adams", "@language": "en"},
+	"description": [
+		{"@value": "English writer and humorist", "@language": "en"},
+		{"@value": "écrivain anglais de science-fiction", "@language": "fr"}
+	],
+	"sameAs": "http://www.wikidata.org/entity/Q42",
+	"image": {
+		"@type": "ImageObject",
+		"contentUrl": "http://upload.wikimedia.org/wikipedia/commons/c/c0/Douglas_adams_portrait_cropped.jpg",
+		"name": "Douglas adams portrait cropped.jpg"
+	}
+}
+```
+
+```
+{
+	"@context": "http://schema.org/",
+	"@type": "GeoCoordinates",
+	"latitude": "45.72",
+	"longitude": "4.82",
+	"@reverse": {
+		"geo": {
+			"@type": "Place",
+			"name": "Lyon",
+			"sameAs": "http://www.wikidata.org/entity/Q456"
+		}
+	}
+}
+```
+
 ### *list*
 It as only one attribute, `list` that is an array that stores the serialization of *list* elements.
 

--- a/data-model.md
+++ b/data-model.md
@@ -175,7 +175,7 @@ A geographic data structure encoded using [GeoJSON](http://geojson.org/). `value
 ##### `resource-jsonld`
 A resource described in [JSON-LD](http://json-ld.org/). `value` is a human readable string representation and `graph` is the JSON-LD graph describing the resource.
 
-The JSON-LD graph should use as much as possible [schema.org vocabulary](http://schema.org/) vocabulary in order to increase interoperability between modules.
+The JSON-LD graph should use as much [schema.org vocabulary](http://schema.org/) vocabulary as possible in order to increase interoperability between modules.
 The graph must be [compacted](http://www.w3.org/TR/json-ld/#compacted-document-form), have as root a [node object](http://www.w3.org/TR/json-ld/#dfn-node-object) describing the resource and use `http://schema.org/` as context.
 
 You must not use the [schema:url](http://schema.org/url) property but instead the [`@id` keyword](http://www.w3.org/TR/json-ld/#node-identifiers).

--- a/data-model.md
+++ b/data-model.md
@@ -180,45 +180,55 @@ The graph must be [compacted](http://www.w3.org/TR/json-ld/#compacted-document-f
 
 You must not use the [schema:url](http://schema.org/url) property but instead the [`@id` keyword](http://www.w3.org/TR/json-ld/#node-identifiers).
 
-Note: use only URIs that identify the same resource as *[schema:sameAs](http://schema.org/sameAs)* value. For example, you can state that Douglas Adams is *schema:sameAs* *http://wikidata.org/entity/Q42* but not *schema:sameAs* *http://en.wikipedia.org/wiki/Douglas_Adams*, because the later is the URI of an article about Douglas Adams but not an URI for Douglas Adams himself.
+Note: You must use as value of *[schema:sameAs](http://schema.org/sameAs)* only URIs that identify the exact same resource as the current one. For example, you can state that Douglas Adams is *schema:sameAs* *http://wikidata.org/entity/Q42* but not *schema:sameAs* *http://en.wikipedia.org/wiki/Douglas_Adams*, because the later is the URI of an article about Douglas Adams but not an URI for Douglas Adams himself.
 
 ```
 {
-    "@context": "http://schema.org/",
-    "@type": "Person",
-    "name": {"@value": "Douglas Adams", "@language": "en"},
-    "description": [
-        {"@value": "English writer and humorist", "@language": "en"},
-        {"@value": "écrivain anglais de science-fiction", "@language": "fr"}
-    ],
-    "sameAs": "http://www.wikidata.org/entity/Q42",
-    "image": {
-        "@type": "ImageObject",
-        "contentUrl": "//upload.wikimedia.org/wikipedia/commons/c/c0/Douglas_adams_portrait_cropped.jpg",
-        "name": "Douglas adams portrait cropped.jpg"
-    },
-    "potentialAction": {
-        "@type": "ViewAction",
-        "name": [{"@value": "View on Wikidata", "@language": "en"}, {"@value": "Voir sur Wikidata", "@language": "fr"}],
-        "image": "//upload.wikimedia.org/wikipedia/commons/f/ff/Wikidata-logo.svg",
-        "target": "//www.wikidata.org/wiki/Q42"
+    "type": "resource",
+    "value-type": "resource-jsonld",
+    "value": "Douglas Adams",
+    "graph": {
+        "@context": "http://schema.org/",
+        "@type": "Person",
+        "name": {"@value": "Douglas Adams", "@language": "en"},
+        "description": [
+            {"@value": "English writer and humorist", "@language": "en"},
+            {"@value": "écrivain anglais de science-fiction", "@language": "fr"}
+        ],
+        "sameAs": "http://www.wikidata.org/entity/Q42",
+        "image": {
+            "@type": "ImageObject",
+            "contentUrl": "//upload.wikimedia.org/wikipedia/commons/c/c0/Douglas_adams_portrait_cropped.jpg",
+            "name": "Douglas adams portrait cropped.jpg"
+        },
+        "potentialAction": {
+            "@type": "ViewAction",
+            "name": [{"@value": "View on Wikidata", "@language": "en"}, {"@value": "Voir sur Wikidata", "@language": "fr"}],
+            "image": "//upload.wikimedia.org/wikipedia/commons/f/ff/Wikidata-logo.svg",
+            "target": "//www.wikidata.org/wiki/Q42"
+        }
     }
 }
 ```
 
 ```
 {
-	"@context": "http://schema.org/",
-	"@type": "GeoCoordinates",
-	"latitude": "45.72",
-	"longitude": "4.82",
-	"@reverse": {
-		"geo": {
-			"@type": "Place",
-			"name": "Lyon",
-			"sameAs": "http://www.wikidata.org/entity/Q456"
-		}
-	}
+    "type": "resource",
+    "value-type": "resource-jsonld",
+    "value": "Douglas Adams",
+    "graph": {
+        "@context": "http://schema.org/",
+        "@type": "GeoCoordinates",
+        "latitude": "45.72",
+        "longitude": "4.82",
+        "@reverse": {
+            "geo": {
+                "@type": "Place",
+                "name": "Lyon",
+                "sameAs": "http://www.wikidata.org/entity/Q456"
+            }
+        }
+    }
 }
 ```
 

--- a/data-model.md
+++ b/data-model.md
@@ -175,12 +175,12 @@ A geographic data structure encoded using [GeoJSON](http://geojson.org/). `value
 ##### `resource-jsonld`
 A resource described in [JSON-LD](http://json-ld.org/). `value` is a human readable string representation and `graph` is the JSON-LD graph describing the resource.
 
-The JSON-LD graph should use as much [schema.org vocabulary](http://schema.org/) vocabulary as possible in order to increase interoperability between modules.
+The JSON-LD graph should use [schema.org vocabulary](http://schema.org/) as much as possible in order to increase interoperability between modules.
 The graph must be [compacted](http://www.w3.org/TR/json-ld/#compacted-document-form), have as root a [node object](http://www.w3.org/TR/json-ld/#dfn-node-object) describing the resource and use `http://schema.org/` as context.
 
 You must not use the [schema:url](http://schema.org/url) property but instead the [`@id` keyword](http://www.w3.org/TR/json-ld/#node-identifiers).
 
-Note: use as *[schema:sameAs](http://schema.org/sameAs)* only URIs that identify the same resource. For example, for Douglas Adams, you can state that he is *schema:sameAs* *http://wikidata.org/entity/Q42* but not *schema:sameAs* *http://en.wikipedia.org/wiki/Douglas_Adams*, because the later is the URI of an article about Douglas Adams but not an URI for Douglas Adams himself.
+Note: use only URIs that identify the same resource as *[schema:sameAs](http://schema.org/sameAs)* value. For example, for Douglas Adams, you can state that he is *schema:sameAs* *http://wikidata.org/entity/Q42* but not *schema:sameAs* *http://en.wikipedia.org/wiki/Douglas_Adams*, because the later is the URI of an article about Douglas Adams but not an URI for Douglas Adams himself.
 
 ```
 {


### PR DESCRIPTION
Adds a kind of resource for JSON-LD graphs based on schema.org vocabulary.

Why JSON-LD and schema.org?
- It allows to use an existing standard to describe various kind of entities (people, places, books, cooking recipes...)
- Easily extensible with other vocabularies if needed
- it's JSON so fits better with the other part of the data model than things like RDF/XML or Turtle
- The "@reverse" feature is very useful to add context to resources (see the second example)